### PR TITLE
修正静态页面资源链接的 test-public 前缀

### DIFF
--- a/dist/about-us.html
+++ b/dist/about-us.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="active">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class=" has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -92,11 +92,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -109,6 +109,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/dist/contact.html
+++ b/dist/contact.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class=" has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="active">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -116,11 +116,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -133,6 +133,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/dist/news.html
+++ b/dist/news.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class=" has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="active">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -61,12 +61,12 @@
         <div class="news-list full">
                             <article class="news-item">
                                             <time datetime="2024-12-18">2024-12-18</time>
-                                        <h2><a href="/news/2024-12-18-key-partner.html">劲捷电子信息入选武汉市智慧城市重点建设合作伙伴</a></h2>
+                                        <h2><a href="/test-public/news/2024-12-18-key-partner.html">劲捷电子信息入选武汉市智慧城市重点建设合作伙伴</a></h2>
                     <p>公司依托智慧城市运营中心、城市物联感知平台等成熟案例，获评“智慧武汉建设优秀集成服务商”。</p>
                 </article>
                             <article class="news-item">
                                             <time datetime="2024-07-02">2024-07-02</time>
-                                        <h2><a href="/news/2024-07-02-omc-launch.html">劲捷运维指挥中心正式上线</a></h2>
+                                        <h2><a href="/test-public/news/2024-07-02-omc-launch.html">劲捷运维指挥中心正式上线</a></h2>
                     <p>全新升级的运维指挥中心具备态势监测、远程诊断、应急调度与知识库服务，实现项目全生命周期可视化管理。</p>
                 </article>
                     </div>
@@ -84,11 +84,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -101,6 +101,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/dist/news/2024-07-02-omc-launch.html
+++ b/dist/news/2024-07-02-omc-launch.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class=" has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="active">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -67,7 +67,7 @@
         <aside class="news-sidebar">
             <h2>更多新闻</h2>
             <ul>
-                                                        <li><a href="/news/2024-12-18-key-partner.html">劲捷电子信息入选武汉市智慧城市重点建设合作伙伴</a></li>
+                                                        <li><a href="/test-public/news/2024-12-18-key-partner.html">劲捷电子信息入选武汉市智慧城市重点建设合作伙伴</a></li>
                                                 </ul>
         </aside>
     </div>
@@ -84,11 +84,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -101,6 +101,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/dist/news/2024-12-18-key-partner.html
+++ b/dist/news/2024-12-18-key-partner.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class=" has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="active">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -67,7 +67,7 @@
         <aside class="news-sidebar">
             <h2>更多新闻</h2>
             <ul>
-                                                                            <li><a href="/news/2024-07-02-omc-launch.html">劲捷运维指挥中心正式上线</a></li>
+                                                                            <li><a href="/test-public/news/2024-07-02-omc-launch.html">劲捷运维指挥中心正式上线</a></li>
                             </ul>
         </aside>
     </div>
@@ -84,11 +84,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -101,6 +101,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/dist/products.html
+++ b/dist/products.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class="active has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -60,24 +60,24 @@
                     </header>
         <div class="grid grid-3">
                             <article class="card">
-                    <h2><a href="/products/smart-city-operations.html">智慧城市运行中心平台</a></h2>
+                    <h2><a href="/test-public/products/smart-city-operations.html">智慧城市运行中心平台</a></h2>
                     <p>打造城市级数据中枢与联动指挥平台，实现“一网统管、一屏统览、一体联动”的智慧治理新模式。</p>
                                             <ul>
                                                             <li>多源数据接入与治理，支持物联、视频、业务系统实时汇聚</li>
                                                             <li>态势可视化驾驶舱，提供指标监测、事件跟踪与专题分析</li>
                                                             <li>协同指挥调度，实现跨部门工单流转、会商研判与应急指挥</li>
                                                     </ul>
-                                        <a class="btn link" href="/products/smart-city-operations.html">查看详情</a>
+                                        <a class="btn link" href="/test-public/products/smart-city-operations.html">查看详情</a>
                 </article>
                             <article class="card">
-                    <h2><a href="/products/low-voltage-integration.html">综合弱电智能化解决方案</a></h2>
+                    <h2><a href="/test-public/products/low-voltage-integration.html">综合弱电智能化解决方案</a></h2>
                     <p>以“安全、稳定、智能”为原则，为园区、医院、教育、企业构建一体化弱电系统，实现基础设施即服务。</p>
                                             <ul>
                                                             <li>结构化综合布线，支持万兆骨干与高速接入</li>
                                                             <li>数据中心与机房建设，满足双路供电与环境监控</li>
                                                             <li>楼宇自控、门禁梯控、视频监控等系统联动</li>
                                                     </ul>
-                                        <a class="btn link" href="/products/low-voltage-integration.html">查看详情</a>
+                                        <a class="btn link" href="/test-public/products/low-voltage-integration.html">查看详情</a>
                 </article>
                     </div>
     </div>
@@ -94,11 +94,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -111,6 +111,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/dist/products/low-voltage-integration.html
+++ b/dist/products/low-voltage-integration.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class="active has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="active">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -57,7 +57,7 @@
         <p class="section-kicker">行业解决方案</p>
         <h1>综合弱电智能化解决方案</h1>
                     <p class="section-intro">以“安全、稳定、智能”为原则，为园区、医院、教育、企业构建一体化弱电系统，实现基础设施即服务。</p>
-                            <a class="btn primary" href="/contact.html">获取项目方案</a>
+                            <a class="btn primary" href="/test-public/contact.html">获取项目方案</a>
             </div>
 </section>
 
@@ -123,11 +123,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -140,6 +140,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>

--- a/dist/products/smart-city-operations.html
+++ b/dist/products/smart-city-operations.html
@@ -9,12 +9,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/test-public/assets/css/style.css">
 </head>
 <body>
 <header class="site-header">
     <div class="container header-inner">
-        <a class="logo" href="/" aria-label="武汉市劲捷电子信息有限公司">
+        <a class="logo" href="/test-public/" aria-label="武汉市劲捷电子信息有限公司">
             <span class="logo-mark" aria-hidden="true">JJ</span>
             <span class="logo-text">
                 <strong>武汉市劲捷电子信息有限公司</strong>
@@ -25,27 +25,27 @@
             <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">菜单</button>
             <ul id="primary-menu" aria-expanded="false">
                                                                             <li class="">
-                        <a href="/">首页</a>
+                        <a href="/test-public/">首页</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/about-us.html">公司介绍</a>
+                        <a href="/test-public/about-us.html">公司介绍</a>
                                             </li>
                                                                             <li class="active has-children">
-                        <a href="/products.html">解决方案</a>
+                        <a href="/test-public/products.html">解决方案</a>
                                                     <ul class="sub-menu">
                                                                     <li class="active">
-                                        <a href="/products/smart-city-operations.html">智慧城市运行中心</a>
+                                        <a href="/test-public/products/smart-city-operations.html">智慧城市运行中心</a>
                                     </li>
                                                                     <li class="">
-                                        <a href="/products/low-voltage-integration.html">弱电智能化</a>
+                                        <a href="/test-public/products/low-voltage-integration.html">弱电智能化</a>
                                     </li>
                                                             </ul>
                                             </li>
                                                                             <li class="">
-                        <a href="/news.html">新闻动态</a>
+                        <a href="/test-public/news.html">新闻动态</a>
                                             </li>
                                                                             <li class="">
-                        <a href="/contact.html">联系我们</a>
+                        <a href="/test-public/contact.html">联系我们</a>
                                             </li>
                             </ul>
         </nav>
@@ -57,7 +57,7 @@
         <p class="section-kicker">行业解决方案</p>
         <h1>智慧城市运行中心平台</h1>
                     <p class="section-intro">打造城市级数据中枢与联动指挥平台，实现“一网统管、一屏统览、一体联动”的智慧治理新模式。</p>
-                            <a class="btn primary" href="/contact.html">预约方案咨询</a>
+                            <a class="btn primary" href="/test-public/contact.html">预约方案咨询</a>
             </div>
 </section>
 
@@ -124,11 +124,11 @@
         <div>
             <h4>快速链接</h4>
             <ul class="footer-links">
-                                    <li><a href="/">首页</a></li>
-                                    <li><a href="/about-us.html">公司介绍</a></li>
-                                    <li><a href="/products.html">解决方案</a></li>
-                                    <li><a href="/news.html">新闻动态</a></li>
-                                    <li><a href="/contact.html">联系我们</a></li>
+                                    <li><a href="/test-public/">首页</a></li>
+                                    <li><a href="/test-public/about-us.html">公司介绍</a></li>
+                                    <li><a href="/test-public/products.html">解决方案</a></li>
+                                    <li><a href="/test-public/news.html">新闻动态</a></li>
+                                    <li><a href="/test-public/contact.html">联系我们</a></li>
                             </ul>
         </div>
         <div>
@@ -141,6 +141,6 @@
         <p>© 2025 武汉市劲捷电子信息有限公司 版权所有. 鄂ICP备 备00000000号-1</p>
     </div>
 </footer>
-<script src="/assets/js/main.js" defer></script>
+<script src="/test-public/assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- 为 dist 目录下的公司介绍、产品、新闻等页面补全 `/test-public/` 前缀，确保样式与脚本资源能在 GitHub Pages 正确加载
- 调整站内导航、按钮与“更多新闻”等内部链接，保证在子路径部署时页面互相跳转正常

## Testing
- Not run (static HTML updates)


------
https://chatgpt.com/codex/tasks/task_e_68d346a94dfc8327be80b88088b4f767